### PR TITLE
feat: add bulk chaining APIs for queueable jobs

### DIFF
--- a/force-app/main/default/classes/Async.cls
+++ b/force-app/main/default/classes/Async.cls
@@ -3,6 +3,14 @@ public inherited sharing class Async {
         return new QueueableBuilder(job);
     }
 
+    public static QueueableBuilder queueable(List<QueueableJob> jobs) {
+        return new QueueableBuilder(jobs);
+    }
+
+    public static QueueableChainBuilder chainBuilder() {
+        return new QueueableChainBuilder();
+    }
+
     public static BatchableBuilder batchable(Object job) {
         return new BatchableBuilder(job);
     }

--- a/force-app/main/default/classes/AsyncTest.cls
+++ b/force-app/main/default/classes/AsyncTest.cls
@@ -2,8 +2,11 @@
  * PMD False Positives:
  * - ApexAssertionsShouldIncludeMessage: IMO not all assertions need a message
  * - EmptyStatementBlock: It is test class, some methods are just to create jobs placeholders
+ * - CognitiveComplexity: Test class with many test methods
  **/
-@SuppressWarnings('PMD.ApexAssertionsShouldIncludeMessage,PMD.EmptyStatementBlock')
+@SuppressWarnings(
+    'PMD.ApexAssertionsShouldIncludeMessage,PMD.EmptyStatementBlock,PMD.CognitiveComplexity'
+)
 @IsTest
 @TestVisible
 private class AsyncTest implements Database.Batchable<SObject> {
@@ -1773,4 +1776,198 @@ private class AsyncTest implements Database.Batchable<SObject> {
         }
     }
 
+    // -- Bulk chaining API tests --
+
+    @IsTest
+    private static void shouldEnqueueListOfQueueablesSuccessfully() {
+        List<QueueableJob> jobs = new List<QueueableJob>();
+        for (Integer i = 0; i < 5; i++) {
+            jobs.add(new SuccessfulQueueableTest());
+        }
+
+        Assert.areEqual(0, [SELECT COUNT() FROM Account]);
+
+        Test.startTest();
+        Async.Result ar = Async.queueable(jobs).enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            QueueableManager.EnqueueType.NEW_CHAIN,
+            ar.queueableChainState.enqueueType,
+            'Should be enqueued as a new chain.'
+        );
+        Assert.areEqual(5, [SELECT COUNT() FROM Account], 'All 5 jobs should have executed.');
+    }
+
+    @IsTest
+    private static void shouldEnqueueListOfQueueablesWithDelaySuccessfully() {
+        List<QueueableJob> jobs = new List<QueueableJob>();
+        for (Integer i = 0; i < 3; i++) {
+            jobs.add(new SuccessfulQueueableTest());
+        }
+
+        Assert.areEqual(0, [SELECT COUNT() FROM Account]);
+
+        Test.startTest();
+        Async.Result ar = Async.queueable(jobs).delay(1).enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            QueueableManager.EnqueueType.NEW_CHAIN,
+            ar.queueableChainState.enqueueType,
+            'Should be enqueued as a new chain.'
+        );
+        Assert.areEqual(3, [SELECT COUNT() FROM Account], 'All 3 jobs should have executed.');
+    }
+
+    @IsTest
+    private static void shouldFailOnEmptyListOfQueueables() {
+        List<QueueableJob> jobs = new List<QueueableJob>();
+
+        Test.startTest();
+        try {
+            Async.queueable(jobs).enqueue();
+            Assert.fail('Should have thrown an exception for empty list.');
+        } catch (Async.IllegalArgumentException e) {
+            Assert.areEqual(
+                QueueableManager.ERROR_MESSAGE_NO_JOB_SET,
+                e.getMessage(),
+                'Should throw no job set error.'
+            );
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void shouldFailOnNullListOfQueueables() {
+        List<QueueableJob> jobs = null;
+
+        Test.startTest();
+        try {
+            Async.queueable(jobs).enqueue();
+            Assert.fail('Should have thrown an exception for null list.');
+        } catch (Async.IllegalArgumentException e) {
+            Assert.areEqual(
+                QueueableManager.ERROR_MESSAGE_NO_JOB_SET,
+                e.getMessage(),
+                'Should throw no job set error.'
+            );
+        }
+        Test.stopTest();
+    }
+
+    @IsTest
+    private static void shouldEnqueueChainBuilderSuccessfully() {
+        Assert.areEqual(0, [SELECT COUNT() FROM Account]);
+
+        Test.startTest();
+        Async.Result ar = Async.chainBuilder()
+            .add(new SuccessfulQueueableTest())
+            .add(new SuccessfulQueueableTest())
+            .add(new SuccessfulQueueableTest())
+            .enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            QueueableManager.EnqueueType.NEW_CHAIN,
+            ar.queueableChainState.enqueueType,
+            'Should be enqueued as a new chain.'
+        );
+        Assert.areEqual(
+            3,
+            [SELECT COUNT() FROM Account],
+            'All 3 jobs from chainBuilder should have executed.'
+        );
+    }
+
+    @IsTest
+    private static void shouldChainWithChainBuilderWithoutEnqueue() {
+        Assert.areEqual(0, [SELECT COUNT() FROM Account]);
+
+        Test.startTest();
+        Async.Result ar = Async.chainBuilder()
+            .add(new SuccessfulQueueableTest())
+            .add(new SuccessfulQueueableTest())
+            .chain();
+
+        // chain() only adds to the chain; enqueue triggers execution
+        Async.queueable(new SuccessfulQueueableTest()).enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            3,
+            [SELECT COUNT() FROM Account],
+            'All 3 jobs should have executed (2 chained + 1 enqueued).'
+        );
+    }
+
+    @IsTest
+    private static void shouldEnqueueChainBuilderWithTwoJobs() {
+        Assert.areEqual(0, [SELECT COUNT() FROM Account]);
+
+        Test.startTest();
+        Async.Result ar = Async.chainBuilder()
+            .add(new SuccessfulQueueableTest())
+            .add(new SuccessfulQueueableTest())
+            .enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(QueueableManager.EnqueueType.NEW_CHAIN, ar.queueableChainState.enqueueType);
+        Assert.areEqual(2, ar.queueableChainState.jobs.size(), 'Chain state should show 2 jobs.');
+        Assert.areEqual(2, [SELECT COUNT() FROM Account], 'Both jobs should have executed.');
+    }
+
+    @IsTest
+    private static void shouldEnqueueChainBuilderWithListOfJobs() {
+        List<QueueableJob> jobs = new List<QueueableJob>();
+        for (Integer i = 0; i < 4; i++) {
+            jobs.add(new SuccessfulQueueableTest());
+        }
+
+        Assert.areEqual(0, [SELECT COUNT() FROM Account]);
+
+        Test.startTest();
+        Async.Result ar = Async.chainBuilder().add(jobs).enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            QueueableManager.EnqueueType.NEW_CHAIN,
+            ar.queueableChainState.enqueueType,
+            'Should be enqueued as a new chain.'
+        );
+        Assert.areEqual(
+            4,
+            [SELECT COUNT() FROM Account],
+            'All 4 jobs from list should have executed.'
+        );
+    }
+
+    @IsTest
+    private static void shouldEnqueueChainBuilderWithListAndSingleJobs() {
+        List<QueueableJob> jobs = new List<QueueableJob>();
+        for (Integer i = 0; i < 3; i++) {
+            jobs.add(new SuccessfulQueueableTest());
+        }
+
+        Assert.areEqual(0, [SELECT COUNT() FROM Account]);
+
+        Test.startTest();
+        Async.Result ar = Async.chainBuilder()
+            .add(new SuccessfulQueueableTest())
+            .add(jobs)
+            .add(new SuccessfulQueueableTest())
+            .enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            QueueableManager.EnqueueType.NEW_CHAIN,
+            ar.queueableChainState.enqueueType,
+            'Should be enqueued as a new chain.'
+        );
+        Assert.areEqual(
+            5,
+            [SELECT COUNT() FROM Account],
+            'All 5 jobs (1 single + 3 list + 1 single) should have executed.'
+        );
+    }
 }

--- a/force-app/main/default/classes/queue/QueueableBuilder.cls
+++ b/force-app/main/default/classes/queue/QueueableBuilder.cls
@@ -5,6 +5,16 @@ public inherited sharing class QueueableBuilder {
         this.job = job.clone();
     }
 
+    public QueueableBuilder(List<QueueableJob> jobs) {
+        if (jobs == null || jobs.isEmpty()) {
+            throw new Async.IllegalArgumentException(QueueableManager.ERROR_MESSAGE_NO_JOB_SET);
+        }
+        for (Integer i = 0; i < jobs.size() - 1; i++) {
+            QueueableManager.get().chain(jobs.get(i));
+        }
+        this.job = jobs.get(jobs.size() - 1).clone();
+    }
+
     public QueueableBuilder asyncOptions(AsyncOptions asyncOptions) {
         if (job.delay != null) {
             throw new IllegalArgumentException(

--- a/force-app/main/default/classes/queue/QueueableChainBuilder.cls
+++ b/force-app/main/default/classes/queue/QueueableChainBuilder.cls
@@ -1,0 +1,20 @@
+public inherited sharing class QueueableChainBuilder {
+    private List<QueueableJob> jobs = new List<QueueableJob>();
+
+    public QueueableChainBuilder add(QueueableJob job) {
+        return add(new List<QueueableJob>{ job });
+    }
+
+    public QueueableChainBuilder add(List<QueueableJob> jobs) {
+        this.jobs.addAll(jobs);
+        return this;
+    }
+
+    public Async.Result enqueue() {
+        return new QueueableBuilder(jobs).enqueue();
+    }
+
+    public Async.Result chain() {
+        return new QueueableBuilder(jobs).chain();
+    }
+}

--- a/force-app/main/default/classes/queue/QueueableChainBuilder.cls-meta.xml
+++ b/force-app/main/default/classes/queue/QueueableChainBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/queue/QueueableManager.cls
+++ b/force-app/main/default/classes/queue/QueueableManager.cls
@@ -3,7 +3,7 @@ public inherited sharing class QueueableManager {
     public static final String ERROR_MESSAGE_ASYNC_OPTIONS_AFTER_DELAY = 'Cannot set asyncOptions after delay has been set';
     public static final String ERROR_MESSAGE_DELAY_AFTER_ASYNC_OPTIONS = 'Cannot set delay after asyncOptions has been set';
     private static final String ERROR_MESSAGE_CHAIN_NULL = 'QueueableChain cannot be null';
-    private static final String ERROR_MESSAGE_NO_JOB_SET = 'No Queueable job has been set to enqueue';
+    public static final String ERROR_MESSAGE_NO_JOB_SET = 'No Queueable job has been set to enqueue';
     private static final String ERROR_MESSAGE_FINALIZER_JOB_NOT_SET = 'No Finalizer job has been set to attach finalizer';
     @TestVisible
     private static final String ERROR_MESSAGE_CANNOT_ATTACH_FINALIZER = 'Cannot attach finalizer when not in a QueueableChain context';

--- a/website/api/queueable.md
+++ b/website/api/queueable.md
@@ -1,8 +1,10 @@
 # Queueable API
 
-Apex classes `QueueableBuilder.cls`, `QueueableManager.cls`, and `QueueableJob.cls`.
+Apex classes `QueueableBuilder.cls`, `QueueableManager.cls`, and
+`QueueableJob.cls`.
 
-For testing patterns and best practices, see [Testing Async Jobs](/explanations/testing-async-jobs).
+For testing patterns and best practices, see
+[Testing Async Jobs](/explanations/testing-async-jobs).
 
 **Common Queueable example:**
 
@@ -21,10 +23,10 @@ Returns `result.customJobId` containing MyQueueableJob's unique Custom Job Id.
 
 ```apex
 public class AccountProcessorJob extends QueueableJob {
-	public override void work() {
-		// Get job context
-		Async.QueueableJobContext ctx = Async.getQueueableJobContext();
-	}
+  public override void work() {
+    // Get job context
+    Async.QueueableJobContext ctx = Async.getQueueableJobContext();
+  }
 }
 ```
 
@@ -32,10 +34,10 @@ public class AccountProcessorJob extends QueueableJob {
 
 ```apex
 private class ProcessorFinalizer extends QueueableJob.Finalizer {
-	public override void work() {
-		// Get finalizer context
-		FinalizerContext finalizerCtx = Async.getQueueableJobContext().finalizerCtx;
-	}
+  public override void work() {
+    // Get finalizer context
+    FinalizerContext finalizerCtx = Async.getQueueableJobContext().finalizerCtx;
+  }
 }
 ```
 
@@ -46,6 +48,8 @@ The following are methods for using Async with Queueable jobs:
 [**INIT**](#init)
 
 - [`queueable(QueueableJob job)`](#queueable)
+- [`queueable(List<QueueableJob> jobs)`](#queueable-list)
+- [`chainBuilder()`](#chainbuilder)
 
 [**Build**](#build)
 
@@ -88,6 +92,81 @@ Async queueable(QueueableJob job);
 
 ```apex
 Async.queueable(new MyQueueableJob());
+```
+
+#### queueable list
+
+Constructs a new QueueableBuilder instance with a list of queueable jobs. All
+jobs except the last are automatically chained in order. The last job becomes
+the active builder target, so builder configuration (e.g. `delay()`,
+`priority()`) applies to it. Throws `IllegalArgumentException` if the list is
+null or empty.
+
+**Signature**
+
+```apex
+QueueableBuilder queueable(List<QueueableJob> jobs);
+```
+
+**Example**
+
+```apex
+List<QueueableJob> jobs = new List<QueueableJob>{
+	new FirstJob(),
+	new SecondJob(),
+	new ThirdJob()
+};
+
+Async.Result result = Async.queueable(jobs)
+	.delay(1)
+	.enqueue();
+```
+
+All three jobs execute sequentially as a single chain. Only one
+`System.enqueueJob()` call is made, avoiding DML governor limit issues when
+enqueuing many jobs.
+
+#### chainBuilder
+
+Creates a new QueueableChainBuilder for incrementally composing a chain of jobs.
+Jobs are added one at a time or in batches via `add()`, then dispatched with
+`enqueue()` or `chain()`.
+
+**Signature**
+
+```apex
+QueueableChainBuilder chainBuilder();
+```
+
+**Example**
+
+```apex
+Async.Result result = Async.chainBuilder()
+	.add(new FirstJob())
+	.add(new SecondJob())
+	.add(new ThirdJob())
+	.enqueue();
+```
+
+**QueueableChainBuilder methods:**
+
+| Method    | Signature                                            | Description                                                                      |
+| --------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `add`     | `QueueableChainBuilder add(QueueableJob job)`        | Adds a single job to the chain                                                   |
+| `add`     | `QueueableChainBuilder add(List<QueueableJob> jobs)` | Adds multiple jobs to the chain                                                  |
+| `enqueue` | `Async.Result enqueue()`                             | Enqueues all added jobs as a single chain                                        |
+| `chain`   | `Async.Result chain()`                               | Adds all jobs to the chain without enqueuing (for nesting inside an outer chain) |
+
+**Batch example:**
+
+```apex
+List<QueueableJob> batchJobs = getBatchJobs();
+
+Async.Result result = Async.chainBuilder()
+	.add(new SetupJob())
+	.add(batchJobs)
+	.add(new CleanupJob())
+	.enqueue();
 ```
 
 ### Build
@@ -253,7 +332,8 @@ Async.Result result = Async.queueable(new MyQueueableJob())
 	.chain(new MyOtherQueueableJob());
 ```
 
-Returns `result.customJobId` containing MyOtherQueueableJob's unique Custom Job Id. To obtain MyQueueableJob's Id, use `chain()` method separately.
+Returns `result.customJobId` containing MyOtherQueueableJob's unique Custom Job
+Id. To obtain MyQueueableJob's Id, use `chain()` method separately.
 
 #### asSchedulable
 
@@ -322,21 +402,21 @@ Async.Result result = Async.queueable(new MyQueueableJob())
 
 **Result properties:**
 
-| Property | Description |
-|----------|-------------|
-| `salesforceJobId` | Salesforce Job Id of either Queueable Job or Initial Queueable Chain Schedulable (empty if job was not the enqueued one in chain) |
-| `customJobId` | Unique Custom Job Id |
-| `asyncType` | `Async.AsyncType.QUEUEABLE` |
-| `queueableChainState` | Chain state object (see below) |
+| Property              | Description                                                                                                                       |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `salesforceJobId`     | Salesforce Job Id of either Queueable Job or Initial Queueable Chain Schedulable (empty if job was not the enqueued one in chain) |
+| `customJobId`         | Unique Custom Job Id                                                                                                              |
+| `asyncType`           | `Async.AsyncType.QUEUEABLE`                                                                                                       |
+| `queueableChainState` | Chain state object (see below)                                                                                                    |
 
 **`queueableChainState` properties:**
 
-| Property | Description |
-|----------|-------------|
-| `jobs` | All jobs in chain including finalizers and processed jobs |
-| `nextSalesforceJobId` | Salesforce Job Id that will run next from chain |
-| `nextCustomJobId` | Custom Job Id that will run next from chain |
-| `enqueueType` | How the chain was enqueued: `EXISTING_CHAIN`, `NEW_CHAIN`, or `INITIAL_QUEUEABLE_CHAIN_SCHEDULABLE` |
+| Property              | Description                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| `jobs`                | All jobs in chain including finalizers and processed jobs                                           |
+| `nextSalesforceJobId` | Salesforce Job Id that will run next from chain                                                     |
+| `nextCustomJobId`     | Custom Job Id that will run next from chain                                                         |
+| `enqueueType`         | How the chain was enqueued: `EXISTING_CHAIN`, `NEW_CHAIN`, or `INITIAL_QUEUEABLE_CHAIN_SCHEDULABLE` |
 
 #### attachFinalizer
 
@@ -380,16 +460,16 @@ Async.QueueableJobContext ctx = Async.getQueueableJobContext();
 
 **Context properties:**
 
-| Property | Description |
-|----------|-------------|
-| `ctx.currentJob` | Current `QueueableJob` instance |
-| `ctx.queueableCtx` | Salesforce `QueueableContext` |
+| Property           | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `ctx.currentJob`   | Current `QueueableJob` instance                         |
+| `ctx.queueableCtx` | Salesforce `QueueableContext`                           |
 | `ctx.finalizerCtx` | Salesforce `FinalizerContext` (available in finalizers) |
 
 #### getQueueableChainSchedulableId
 
-Gets the ID of the initial Queueable Chain Schedulable if the current execution is part of
-a scheduled-based chain.
+Gets the ID of the initial Queueable Chain Schedulable if the current execution
+is part of a scheduled-based chain.
 
 **Signature**
 
@@ -423,9 +503,9 @@ QueueableChainState currentChain = Async.getCurrentQueueableChainState();
 
 **Chain state properties:**
 
-| Property | Description |
-|----------|-------------|
-| `jobs` | All jobs in chain including processed ones and finalizers |
+| Property              | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `jobs`                | All jobs in chain including processed ones and finalizers          |
 | `nextSalesforceJobId` | Salesforce Job Id that will run next (empty if chain not enqueued) |
-| `nextCustomJobId` | Custom Job Id that will run next from chain |
-| `enqueueType` | Empty until set during `enqueue()` method |
+| `nextCustomJobId`     | Custom Job Id that will run next from chain                        |
+| `enqueueType`         | Empty until set during `enqueue()` method                          |


### PR DESCRIPTION
Add Async.queueable(List<QueueableJob>) factory method and QueueableBuilder List constructor to enqueue multiple jobs as a single chain in one call.

Add QueueableChainBuilder class with fluent add()/enqueue()/chain() API for incremental chain composition via Async.chainBuilder().

Includes 9 new test methods covering happy paths, edge cases, and mixed usage.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Changes Made

<!-- List the specific changes made in this PR -->

## Motivation

When enqueuing many queueable jobs in a loop, the current API requires manual chain bookkeeping:

```apex
List<QueueableJob> jobs = getJobs(); // e.g. 500 jobs

for (Integer i = 0; i < jobs.size() - 1; i++) {
    Async.queueable(jobs[i]).chain();
}
Async.queueable(jobs[jobs.size() - 1]).enqueue();
```

This is verbose, error-prone (off-by-one on the last job, forgetting to call `enqueue()` separately), and doesn't feel like the rest of the fluent API.
### Why this matters for high job counts

The motivation section above focuses on code ergonomics, but there's a more critical reason: **the current loop pattern hits governor limits**.

When you enqueue jobs individually in a loop:

```apex
for (Integer i = 0; i < 500; i++) {
    Async.queueable(new MyQueueableJob()).enqueue();
}
```

Each `.enqueue()` call creates a **separate chain**. After the 50th `System.enqueueJob()` (Salesforce limit per synchronous transaction), every subsequent call overflows into `QueueableChain.executeOrReplaceInitialQueueableChainSchedulableJob()`, which calls `System.abortJob()` + `System.schedule()` — **2 DML statements per overflow job**:

| Jobs | What happens | DML per job | Total DML |
|------|-------------|-------------|-----------|
| 1–50 | `System.enqueueJob()` — each creates its own chain | 1 | 50 |
| 51 | `System.schedule()` (first overflow, no abort) | 1 | 1 |
| 52–100 | `System.abortJob()` + `System.schedule()` | 2 | 98 |
| **Total** | | | **149** |

At **101 jobs you hit `System.LimitException: Too many DML statements: 151`**.

### How the new APIs solve this

`Async.queueable(list).enqueue()` and `Async.chainBuilder()...enqueue()` put all jobs into a **single chain** with **one** `System.enqueueJob()` call. The overflow mechanism fires at most once (1 `System.schedule()`), so DML stays at **~2 total** regardless of job count — making 500+ jobs safe.

```apex
// ✅ 500 jobs, 1 chain, ~2 DML total
List<QueueableJob> jobs = new List<QueueableJob>();
for (Integer i = 0; i < 500; i++) {
    jobs.add(new MyQueueableJob());
}
Async.queueable(jobs).enqueue();
```

## What this PR adds

Two new entry points that stay consistent with the existing `Async.*` design language:

### 1. `Async.queueable(List<QueueableJob>)` — when you already have a list

```apex
List<QueueableJob> jobs = new List<QueueableJob>{
    new SendEmailJob(),
    new UpdateRecordsJob(),
    new NotifyExternalServiceJob()
};

Async.queueable(jobs).enqueue();
```

All jobs are automatically chained in order. The last job becomes the active builder target, so you can still apply configuration:

```apex
Async.queueable(jobs)
    .delay(1)
    .enqueue();
```

Validates input — `null` or empty list throws `IllegalArgumentException`.

### 2. `Async.chainBuilder()` — when you're composing incrementally

```apex
Async.chainBuilder()
    .add(new SendEmailJob())
    .add(new UpdateRecordsJob())
    .add(new NotifyExternalServiceJob())
    .enqueue();
```

Supports adding jobs one at a time or in batches:

```apex
List<QueueableJob> batchJobs = getBatchJobs();

Async.chainBuilder()
    .add(new SetupJob())
    .add(batchJobs)             // add a whole list at once
    .add(new CleanupJob())
    .enqueue();
```

Also supports `.chain()` instead of `.enqueue()` for nesting inside an outer chain.

## Changes

| File | Change |
|------|--------|
| `Async.cls` | Added `queueable(List<QueueableJob>)` and `chainBuilder()` factory methods |
| `QueueableBuilder.cls` | Added `QueueableBuilder(List<QueueableJob>)` constructor — chains N-1 jobs, sets last as active |
| `QueueableChainBuilder.cls` | **New** — fluent builder with `add(job)`, `add(list)`, `enqueue()`, `chain()` |
| `AsyncTest.cls` | 9 new test methods covering happy paths, edge cases, and mixed usage |

## Test coverage

- `shouldEnqueueListOfQueueablesSuccessfully` — 5 jobs via list
- `shouldEnqueueListOfQueueablesWithDelaySuccessfully` — list + `.delay(1)`
- `shouldFailOnEmptyListOfQueueables` — empty list → exception
- `shouldFailOnNullListOfQueueables` — null → exception
- `shouldEnqueueChainBuilderSuccessfully` — 3 jobs via chainBuilder
- `shouldChainWithChainBuilderWithoutEnqueue` — `.chain()` instead of `.enqueue()`
- `shouldEnqueueChainBuilderWithTwoJobs` — verifies chain state job count
- `shouldEnqueueChainBuilderWithListOfJobs` — `add(list)` with 4 jobs
- `shouldEnqueueChainBuilderWithListAndSingleJobs` — mixed `add(single)` + `add(list)` = 5 jobs
## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Closes #

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] All existing tests pass (`npm test`)
- [x] Added new tests for new functionality
- [x] Tested in scratch org
- [x] Linting passes (`npm run lint`)
- [x] Code formatting is correct (`npm run prettier:verify`)

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information that reviewers should know -->
