### PR TITLE
Add Async.queueable() no-arg builder for conditional chaining

### DIFF
--- a/force-app/main/default/classes/Async.cls
+++ b/force-app/main/default/classes/Async.cls
@@ -3,6 +3,10 @@ public inherited sharing class Async {
         return new QueueableBuilder(job);
     }
 
+    public static QueueableBuilder queueable() {
+        return new QueueableBuilder();
+    }
+
     public static BatchableBuilder batchable(Object job) {
         return new BatchableBuilder(job);
     }

--- a/force-app/main/default/classes/AsyncTest.cls
+++ b/force-app/main/default/classes/AsyncTest.cls
@@ -1003,6 +1003,96 @@ private class AsyncTest implements Database.Batchable<SObject> {
     }
 
     @IsTest
+    static void shouldEnqueueNothingForEmptyBuilder() {
+        Test.startTest();
+        Async.Result result = Async.queueable().enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            0,
+            [
+                SELECT COUNT()
+                FROM AsyncApexJob
+                WHERE JobType = 'Queueable' AND ApexClass.Name = 'AsyncTest'
+            ],
+            'No queueable should be enqueued from an empty builder.'
+        );
+        Assert.areEqual(null, result.salesforceJobId, 'No salesforceJobId expected.');
+        Assert.areEqual(
+            0,
+            result.queueableChainState.jobs.size(),
+            'Chain state should report zero jobs.'
+        );
+    }
+
+    @IsTest
+    static void shouldEnqueueSingleJobAddedViaChainOnEmptyBuilder() {
+        QueueableJobTest1 job1 = new QueueableJobTest1();
+
+        Test.startTest();
+        Async.Result result = Async.queueable().chain(job1).enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            1,
+            result.queueableChainState.jobs.size(),
+            'Chain should contain the single added job.'
+        );
+        Assert.areNotEqual(null, result.salesforceJobId, 'A job should have been enqueued.');
+    }
+
+    @IsTest
+    static void shouldEnqueueMultipleJobsAddedViaRepeatedChainOnEmptyBuilder() {
+        QueueableJobTest1 job1 = new QueueableJobTest1();
+        QueueableJobTest2 job2 = new QueueableJobTest2();
+        QueueableJobTest3 job3 = new QueueableJobTest3();
+
+        Test.startTest();
+        QueueableBuilder builder = Async.queueable();
+        builder.chain(job1);
+        builder.chain(job2);
+        builder.chain(job3);
+        Async.Result result = builder.enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            3,
+            result.queueableChainState.jobs.size(),
+            'Chain should contain all three jobs in the order they were added.'
+        );
+    }
+
+    @IsTest
+    static void shouldOnlyChainBranchesThatMatchConditionOnEmptyBuilder() {
+        QueueableJobTest1 job1 = new QueueableJobTest1();
+        QueueableJobTest2 job2 = new QueueableJobTest2();
+        QueueableJobTest3 job3 = new QueueableJobTest3();
+        Boolean addJob1 = true;
+        Boolean addJob2 = false;
+        Boolean addJob3 = true;
+
+        Test.startTest();
+        QueueableBuilder builder = Async.queueable();
+        if (addJob1) {
+            builder.chain(job1);
+        }
+        if (addJob2) {
+            builder.chain(job2);
+        }
+        if (addJob3) {
+            builder.chain(job3);
+        }
+        Async.Result result = builder.enqueue();
+        Test.stopTest();
+
+        Assert.areEqual(
+            2,
+            result.queueableChainState.jobs.size(),
+            'Only branches whose condition was true should be in the chain.'
+        );
+    }
+
+    @IsTest
     static void shouldFailToSetAsyncOptionsAfterDelay() {
         SuccessfulQueueableTest q = new SuccessfulQueueableTest();
 
@@ -1848,5 +1938,4 @@ private class AsyncTest implements Database.Batchable<SObject> {
             insert new Account(Name = accountName, Description = 'Job: ' + jobId);
         }
     }
-
 }

--- a/force-app/main/default/classes/queue/QueueableBuilder.cls
+++ b/force-app/main/default/classes/queue/QueueableBuilder.cls
@@ -5,6 +5,9 @@ public inherited sharing class QueueableBuilder {
         this.job = job.clone();
     }
 
+    public QueueableBuilder() {
+    }
+
     public QueueableBuilder asyncOptions(AsyncOptions asyncOptions) {
         if (job.delay != null) {
             throw new IllegalArgumentException(
@@ -58,7 +61,9 @@ public inherited sharing class QueueableBuilder {
     }
 
     public QueueableBuilder chain(QueueableJob job) {
-        chain();
+        if (this.job != null) {
+            chain();
+        }
         this.job = job;
         return this;
     }
@@ -76,6 +81,12 @@ public inherited sharing class QueueableBuilder {
     }
 
     public Async.Result enqueue() {
+        if (this.job == null) {
+            return new Async.Result((Id) null)
+                .setQueueableChainState(
+                    new Async.QueueableChainState().setJobs(new List<QueueableJob>())
+                );
+        }
         return QueueableManager.get().chainAndEnqueue(job);
     }
 }

--- a/website/api/queueable.md
+++ b/website/api/queueable.md
@@ -1,8 +1,10 @@
 # Queueable API
 
-Apex classes `QueueableBuilder.cls`, `QueueableManager.cls`, and `QueueableJob.cls`.
+Apex classes `QueueableBuilder.cls`, `QueueableManager.cls`, and
+`QueueableJob.cls`.
 
-For testing patterns and best practices, see [Testing Async Jobs](/explanations/testing-async-jobs).
+For testing patterns and best practices, see
+[Testing Async Jobs](/explanations/testing-async-jobs).
 
 **Common Queueable example:**
 
@@ -21,10 +23,10 @@ Returns `result.customJobId` containing MyQueueableJob's unique Custom Job Id.
 
 ```apex
 public class AccountProcessorJob extends QueueableJob {
-	public override void work() {
-		// Get job context
-		Async.QueueableJobContext ctx = Async.getQueueableJobContext();
-	}
+  public override void work() {
+    // Get job context
+    Async.QueueableJobContext ctx = Async.getQueueableJobContext();
+  }
 }
 ```
 
@@ -32,10 +34,10 @@ public class AccountProcessorJob extends QueueableJob {
 
 ```apex
 private class ProcessorFinalizer extends QueueableJob.Finalizer {
-	public override void work() {
-		// Get finalizer context
-		FinalizerContext finalizerCtx = Async.getQueueableJobContext().finalizerCtx;
-	}
+  public override void work() {
+    // Get finalizer context
+    FinalizerContext finalizerCtx = Async.getQueueableJobContext().finalizerCtx;
+  }
 }
 ```
 
@@ -46,6 +48,7 @@ The following are methods for using Async with Queueable jobs:
 [**INIT**](#init)
 
 - [`queueable(QueueableJob job)`](#queueable)
+- [`queueable()`](#queueable-no-args)
 
 [**Build**](#build)
 
@@ -88,6 +91,36 @@ Async queueable(QueueableJob job);
 
 ```apex
 Async.queueable(new MyQueueableJob());
+```
+
+#### queueable (no args) {#queueable-no-args}
+
+Constructs an empty QueueableBuilder so jobs can be added incrementally via
+`chain(QueueableJob)`. Useful when the number of jobs to enqueue depends on
+runtime conditions — calling `enqueue()` on a builder with zero jobs is a safe
+no-op.
+
+**Signature**
+
+```apex
+QueueableBuilder queueable();
+```
+
+**Example**
+
+```apex
+QueueableBuilder builder = Async.queueable();
+if (needsJob1) {
+	builder.chain(new Job1());
+}
+if (needsJob2) {
+	builder.chain(new Job2());
+}
+if (needsJob3) {
+	builder.chain(new Job3());
+}
+// Enqueues whatever was added; does nothing if none were.
+builder.enqueue();
 ```
 
 ### Build
@@ -202,8 +235,9 @@ Clones provided QueueableJob by value for all the member variables. By default
 only primitive member variables (String, Boolean, ...) are cloned by value.
 Deeper explanation is [here](/explanations/job-cloning).
 
-::: warning Package Usage
-When using Async Lib as a package (`btcdev` namespace), deep clone requires overriding `cloneForDeepCopy()` in your subclass. See [Deep Clone in Packages](/explanations/deep-clone-in-packages).
+::: warning Package Usage When using Async Lib as a package (`btcdev`
+namespace), deep clone requires overriding `cloneForDeepCopy()` in your
+subclass. See [Deep Clone in Packages](/explanations/deep-clone-in-packages).
 :::
 
 **Signature**
@@ -257,7 +291,8 @@ Async.Result result = Async.queueable(new MyQueueableJob())
 	.chain(new MyOtherQueueableJob());
 ```
 
-Returns `result.customJobId` containing MyOtherQueueableJob's unique Custom Job Id. To obtain MyQueueableJob's Id, use `chain()` method separately.
+Returns `result.customJobId` containing MyOtherQueueableJob's unique Custom Job
+Id. To obtain MyQueueableJob's Id, use `chain()` method separately.
 
 #### asSchedulable
 
@@ -326,21 +361,21 @@ Async.Result result = Async.queueable(new MyQueueableJob())
 
 **Result properties:**
 
-| Property | Description |
-|----------|-------------|
-| `salesforceJobId` | Salesforce Job Id of either Queueable Job or Initial Queueable Chain Schedulable (empty if job was not the enqueued one in chain) |
-| `customJobId` | Unique Custom Job Id |
-| `asyncType` | `Async.AsyncType.QUEUEABLE` |
-| `queueableChainState` | Chain state object (see below) |
+| Property              | Description                                                                                                                       |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `salesforceJobId`     | Salesforce Job Id of either Queueable Job or Initial Queueable Chain Schedulable (empty if job was not the enqueued one in chain) |
+| `customJobId`         | Unique Custom Job Id                                                                                                              |
+| `asyncType`           | `Async.AsyncType.QUEUEABLE`                                                                                                       |
+| `queueableChainState` | Chain state object (see below)                                                                                                    |
 
 **`queueableChainState` properties:**
 
-| Property | Description |
-|----------|-------------|
-| `jobs` | All jobs in chain including finalizers and processed jobs |
-| `nextSalesforceJobId` | Salesforce Job Id that will run next from chain |
-| `nextCustomJobId` | Custom Job Id that will run next from chain |
-| `enqueueType` | How the chain was enqueued: `EXISTING_CHAIN`, `NEW_CHAIN`, or `INITIAL_QUEUEABLE_CHAIN_SCHEDULABLE` |
+| Property              | Description                                                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| `jobs`                | All jobs in chain including finalizers and processed jobs                                           |
+| `nextSalesforceJobId` | Salesforce Job Id that will run next from chain                                                     |
+| `nextCustomJobId`     | Custom Job Id that will run next from chain                                                         |
+| `enqueueType`         | How the chain was enqueued: `EXISTING_CHAIN`, `NEW_CHAIN`, or `INITIAL_QUEUEABLE_CHAIN_SCHEDULABLE` |
 
 #### attachFinalizer
 
@@ -384,16 +419,16 @@ Async.QueueableJobContext ctx = Async.getQueueableJobContext();
 
 **Context properties:**
 
-| Property | Description |
-|----------|-------------|
-| `ctx.currentJob` | Current `QueueableJob` instance |
-| `ctx.queueableCtx` | Salesforce `QueueableContext` |
+| Property           | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `ctx.currentJob`   | Current `QueueableJob` instance                         |
+| `ctx.queueableCtx` | Salesforce `QueueableContext`                           |
 | `ctx.finalizerCtx` | Salesforce `FinalizerContext` (available in finalizers) |
 
 #### getQueueableChainSchedulableId
 
-Gets the ID of the initial Queueable Chain Schedulable if the current execution is part of
-a scheduled-based chain.
+Gets the ID of the initial Queueable Chain Schedulable if the current execution
+is part of a scheduled-based chain.
 
 **Signature**
 
@@ -427,9 +462,9 @@ QueueableChainState currentChain = Async.getCurrentQueueableChainState();
 
 **Chain state properties:**
 
-| Property | Description |
-|----------|-------------|
-| `jobs` | All jobs in chain including processed ones and finalizers |
+| Property              | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `jobs`                | All jobs in chain including processed ones and finalizers          |
 | `nextSalesforceJobId` | Salesforce Job Id that will run next (empty if chain not enqueued) |
-| `nextCustomJobId` | Custom Job Id that will run next from chain |
-| `enqueueType` | Empty until set during `enqueue()` method |
+| `nextCustomJobId`     | Custom Job Id that will run next from chain                        |
+| `enqueueType`         | Empty until set during `enqueue()` method                          |

--- a/website/api/queueable.md
+++ b/website/api/queueable.md
@@ -361,12 +361,13 @@ Async.Result result = Async.queueable(new MyQueueableJob())
 
 **Result properties:**
 
-| Property              | Description                                                                                                                       |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `salesforceJobId`     | Salesforce Job Id of either Queueable Job or Initial Queueable Chain Schedulable (empty if job was not the enqueued one in chain) |
-| `customJobId`         | Unique Custom Job Id                                                                                                              |
-| `asyncType`           | `Async.AsyncType.QUEUEABLE`                                                                                                       |
-| `queueableChainState` | Chain state object (see below)                                                                                                    |
+| Property              | Description                                                                                                                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `salesforceJobId`     | Salesforce Job Id of the actually-enqueued first-chain Queueable Job or Initial Queueable Chain Schedulable. `null` when `enqueue()` is called on an empty `Async.queueable()` builder with no jobs added.                                         |
+| `customJobId`         | Unique Custom Job Id                                                                                                                                                                                                                               |
+| `asyncType`           | `Async.AsyncType.QUEUEABLE`                                                                                                                                                                                                                        |
+| `job`                 | The `QueueableJob` instance that the builder was finalized with. Useful for inspecting post-enqueue state, especially the cloned instance when `.deepClone()` was used. `null` when `enqueue()` is called on an empty `Async.queueable()` builder. |
+| `queueableChainState` | Chain state object (see below)                                                                                                                                                                                                                     |
 
 **`queueableChainState` properties:**
 


### PR DESCRIPTION
## Summary
- Add `Async.queueable()` no-arg overload + matching `QueueableBuilder()` constructor so jobs can be chained incrementally
- `chain(QueueableJob)` skips the implicit `chain()` step when the builder has no current job, so the first `.chain(job)` on an empty builder becomes the first job in the chain
- `enqueue()` on an empty builder returns a `Result` with `null` `salesforceJobId` and an empty `QueueableChainState` (no-op, no exception)
- Document the new entry point + add `Result.job` and clarify the `salesforceJobId` description in `website/api/queueable.md`
- Add 4 new `AsyncTest` methods: empty enqueue, single chain on empty builder, multi-chain via repeated `.chain()`, and conditional-branch chaining

## Why
Closes #28. Lets callers build a chain whose membership depends on runtime conditions without workarounds:

```apex
QueueableBuilder builder = Async.queueable();
if (cond1) { builder.chain(new Job1()); }
if (cond2) { builder.chain(new Job2()); }
if (cond3) { builder.chain(new Job3()); }
builder.enqueue(); // enqueues whatever was added; no-op if nothing was
```

## Test plan
- [x] `bash scripts/agent/verify.sh full` (CI-parity local Apex tests + coverage)
- [x] `bash scripts/agent/verify.sh ns` (btcdev-namespaced scratch — package-install perspective)

## Files
- `force-app/main/default/classes/Async.cls` (+4)
- `force-app/main/default/classes/queue/QueueableBuilder.cls` (+11, -2)
- `force-app/main/default/classes/AsyncTest.cls` (+90, -1)
- `website/api/queueable.md` (+73, -35)

Closes #28