### PR TITLE
Enable clean URLs for docs site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "npm run docs:build",
   "outputDirectory": "website/.vitepress/dist",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "cleanUrls": true
 }

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vitepress';
 export default defineConfig({
   title: 'Async Lib',
   description: 'Async Lib Documentation',
+  cleanUrls: true,
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }],
     [


### PR DESCRIPTION
## Summary
- Re-enable `cleanUrls: true` in VitePress config so built internal links drop the `.html` suffix.
- Add `cleanUrls: true` to `vercel.json` so the host serves pages at the clean path and 308-redirects any `.html` request to it.

## Why
Doc pages open blank when the URL is hit without `.html` (e.g. links pasted into GitHub release notes), while the `.html` form works. Root cause: `cleanUrls: true` was removed from the VitePress config in Aug 2025 (commit b74bd9d, "Fix"), so the site has been `.html`-only since. In-site navigation still worked because VitePress rewrites internal links, but direct/external clean URLs 404 to a blank shell.

Setting it on both layers fixes it host-side, so no per-link `.html` bookkeeping in release notes. Old `.html` links keep working via the redirect.

## Test plan
- [x] `npm run docs:build` succeeds; built internal hrefs now omit `.html` (verified in dist)
- [ ] On the Vercel preview: open `/explanations/asyncresult-cleanup` (renders) and `/explanations/asyncresult-cleanup.html` (308-redirects to the clean path)

## Files
- vercel.json
- website/.vitepress/config.mts